### PR TITLE
Fixes the issue of iOS-logout

### DIFF
--- a/www/app/main-module.js
+++ b/www/app/main-module.js
@@ -231,7 +231,7 @@
     // logout func
     $rootScope.logout = function () {
       userService.logout();
-      location.reload();
+      $state.go("login")
     };
 
     $rootScope.deleteUser = function () {


### PR DESCRIPTION
### Note: I don't have an iPhone, but i do have a Macbook (+Safari) which repeated the problem. Pls test out the solution before accepting

The problem is caused by errorCallback & userService.logout on user-service.js. Logout is called correctly, but after destroying the user's session correctly, the browser is asked to reload, excepting it to navigate its way back to login screen. Correct way to handle this would be send the user to a designated logout-page, but there is none available, so all I changed is changing` location.reload()` to `state.go("login")` (took quite long time to track it down though)

When the browser receives the logout-function call, it destroys the session and tries to reload the current page --> resulting into all the API's responding with 401 (Not authorized), which triggers errorCallback ("Serveri ei vastaa"). Responding here triggers another 401, because the user sessions is now destroyed etc...

To my understanding, the error handling or nothing else is telling the browser it needs to go back to Login-screen (there is no 401-error code handling in the entire repo). Why Chrome can do this, but Safari doesn't, is not in my knowledge.

fixes #5 (at least on my Safari)